### PR TITLE
feat: Implement Export to Markdown functionality

### DIFF
--- a/Aila.csproj
+++ b/Aila.csproj
@@ -61,6 +61,8 @@
         <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)"/>
         <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)"/>
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>
+        <PackageReference Include="ReverseMarkdown" Version="3.2.0" />
+        <PackageReference Include="CommunityToolkit.Maui" Version="7.0.1" />
     </ItemGroup>
 
 </Project>

--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using CommunityToolkit.Maui; // Add this using
 
 namespace Aila;
 
@@ -9,6 +10,7 @@ public static class MauiProgram
         var builder = MauiApp.CreateBuilder();
         builder
             .UseMauiApp<App>()
+            .UseMauiCommunityToolkit() // Add this line
             .ConfigureFonts(fonts =>
             {
                 fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");


### PR DESCRIPTION
This feature allows you to export the content of the focused AI WebView to a Markdown file.

Key changes:
- Added an "Export as MD" button to the toolbar in `MainPage.xaml.cs`. This button becomes visible when an AI view is in full-screen mode.
- Implemented logic in `OnExportToMarkdownClicked` to:
  - Retrieve the full HTML content of the focused WebView using JavaScript (`document.documentElement.outerHTML`).
  - Convert the HTML content to Markdown format using the `ReverseMarkdown` library.
- Added the `ReverseMarkdown` NuGet package (version 3.2.0) to `Aila.csproj`.
- Added the `CommunityToolkit.Maui` NuGet package (version 7.0.1) to `Aila.csproj` (if not already present) and updated `MauiProgram.cs` to include `.UseMauiCommunityToolkit()`.
- Implemented file saving using `CommunityToolkit.Maui.Storage.FileSaver` to allow you to choose the save location and filename for the Markdown file.
- Refined toolbar item management in `MainPage.xaml.cs` to accommodate the new button and handle its visibility.
- Added helper methods for managing WebView layout information to ensure proper restoration from full-screen mode.

Manual testing is required to verify the end-to-end functionality across different AIs and platforms.