### PR TITLE
Remove WeChat payment QR codes from READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,4 @@ Thank you for exploring Aila Desktop Application. We look forward to seeing the 
 
 <img src="https://github.com/win4r/AISuperDomain/assets/42172631/d6dcfd1a-60fa-4b6f-9d5e-1482150a7d95" width="186" height="300">
 <img src="https://github.com/win4r/AISuperDomain/assets/42172631/7568cf78-c8ba-4182-aa96-d524d903f2bc" width="214.8" height="291">
-<img src="https://github.com/win4r/AISuperDomain/assets/42172631/fefe535c-8153-4046-bfb4-e65eacbf7a33" width="207" height="281">
-
 

--- a/README_ZH-CN.md
+++ b/README_ZH-CN.md
@@ -95,4 +95,3 @@ AI超元域桌面应用在MIT许可证下发布。更多细节，请查看LICENS
 
 <img src="https://github.com/win4r/AISuperDomain/assets/42172631/d6dcfd1a-60fa-4b6f-9d5e-1482150a7d95" width="186" height="300">
 <img src="https://github.com/win4r/AISuperDomain/assets/42172631/7568cf78-c8ba-4182-aa96-d524d903f2bc" width="214.8" height="291">
-<img src="https://github.com/win4r/AISuperDomain/assets/42172631/fefe535c-8153-4046-bfb4-e65eacbf7a33" width="207" height="281">

--- a/README_ZH-TW.md
+++ b/README_ZH-TW.md
@@ -97,5 +97,3 @@ AI超元域桌面應用在MIT許可證下發布。更多細節，請查看LICENS
 
 <img src="https://github.com/win4r/AISuperDomain/assets/42172631/d6dcfd1a-60fa-4b6f-9d5e-1482150a7d95" width="186" height="300">
 <img src="https://github.com/win4r/AISuperDomain/assets/42172631/7568cf78-c8ba-4182-aa96-d524d903f2bc" width="214.8" height="291">
-<img src="https://github.com/win4r/AISuperDomain/assets/42172631/fefe535c-8153-4046-bfb4-e65eacbf7a33" width="207" height="281">
-


### PR DESCRIPTION
## What changed

- Removed the WeChat payment QR code from `README.md`.
- Removed the same payment QR code from `README_ZH-CN.md` and `README_ZH-TW.md`.
- Kept the WeChat group QR code and personal WeChat QR code unchanged.
- Confirmed that the French, Japanese, and Korean READMEs do not contain the payment QR code.

## Why

The same WeChat payment QR image was embedded in the English, Simplified Chinese, and Traditional Chinese READMEs. This change removes that payment code consistently across all affected language variants.

## Impact

Documentation-only change. No application code or behavior is affected.

## Validation

- `git diff --check`
- Verified the payment QR asset reference is absent from every `README*` file.
- Visually confirmed the retained QR images are for the WeChat group and personal WeChat contact.